### PR TITLE
Use `reinterpret` instead of `Base.bitcast`

### DIFF
--- a/src/EnumX.jl
+++ b/src/EnumX.jl
@@ -125,7 +125,7 @@ function enumx(_module_, args)
                 throw(ArgumentError("invalid value for Enum $($(QuoteNode(modname))): $(x)."))
             global function $(esc(T))(x::Integer)
                 check_valid(x)
-                return Base.bitcast($(esc(T)), convert($(baseT), x))
+                return reinterpret($(esc(T)), convert($(baseT), x))
             end
             Base.Enums.namemap(::Base.Type{$(esc(T))}) = value_name_map
             Base.Enums.instances(::Base.Type{$(esc(T))}) =


### PR DESCRIPTION
There are two advantages in using `reinterpret` instead of `Base.bitcast`.
1. `reinterpret` is exported while `Base.bitcast` is private
2. `reinterpret` can handle `isbitstype`s, while `Base.bitcast` is limited to `primitive type`s (being a subgroup of `isbitstype`). The main difference is the typical type wrapper which is an immutable struct with only a single field and therefore an `isbitstype`, but not a `primitive type`.

There does not seem to be a disadvantage as they seem to result in the same LLVM code and therefore native code:
```julia
primitive type MyPrimitive 8 end
f(type, value) = Base.bitcast(type, value)
g(type, value) = reinterpret(type, value)
const v = UInt8(42)

julia> @code_llvm(debuginfo=:none, f(MyPrimitive, v))
; Function Signature: f(Type{Main.MyPrimitive}, UInt8)
define i8 @julia_f_9216(i8 zeroext %"value::UInt8") #0 {
top:
  ret i8 %"value::UInt8"
}

julia> @code_llvm(debuginfo=:none, g(MyPrimitive, v))
; Function Signature: g(Type{Main.MyPrimitive}, UInt8)
define i8 @julia_g_9220(i8 zeroext %"value::UInt8") #0 {
top:
  ret i8 %"value::UInt8"
}
```