### PR TITLE
Make two-arg `show` round-trippable under `:compact`

### DIFF
--- a/src/EnumX.jl
+++ b/src/EnumX.jl
@@ -155,6 +155,23 @@ function enumx(_module_, args)
     return Expr(:toplevel, Expr(:module, false, esc(modname), module_block), mdoc, #=Tdoc,=# nothing)
 end
 
+# Base's fallback `show` for `Enum` qualifies the instance name with the full
+# module path (e.g. `Main.Fruit.Apple`) by default, but drops the qualifier when
+# `IOContext` has `:compact => true` or when the bare symbol is visible from
+# `:module`. Neither matches `EnumX`'s `Module.Name` convention (which is what
+# the 3-arg show emits, see below). Override here to keep the form consistent
+# and round-trippable across all contexts.
+function Base.show(io::IO, x::E) where {E <: Enum}
+    ix = Integer(x)
+    for (k, v) in symbol_map(E)
+        if v == ix
+            print(io, nameof(parentmodule(E)), '.', k)
+            return nothing
+        end
+    end
+    print(io, nameof(parentmodule(E)), ".#invalid#")
+    return nothing
+end
 function Base.show(io::IO, ::MIME"text/plain", x::E) where {E <: Enum}
     iob = IOBuffer()
     ix = Integer(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,6 +91,13 @@ const Ananab = -1
         @test str == "EnumX.Enum{Int32}"
     end
 
+    # Two-arg `show` should always emit `Module.Name` (the `EnumX` convention)
+    # so that `repr(x)` round-trips. Without our override Base's fallback prints
+    # just the bare instance name under `:compact => true`, which is unparseable
+    # since `EnumX` instances live inside the auto-generated module.
+    @test sprint(show, Fruit.Apple;  context = :compact => true) == "Fruit.Apple"
+    @test sprint(show, Fruit.Banana; context = :compact => true) == "Fruit.Banana"
+
 
     # Base type specification
     @enumx Fruit8::Int8 Apple

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -311,6 +311,7 @@ const Ananab = -1
         show(io, "text/plain", invalid)
         str = String(take!(io))
         @test str == "Invalid.#invalid# = 1"
+        @test sprint(show, invalid) == "Invalid.#invalid#"
     end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,7 +95,7 @@ const Ananab = -1
     # so that `repr(x)` round-trips. Without our override Base's fallback prints
     # just the bare instance name under `:compact => true`, which is unparseable
     # since `EnumX` instances live inside the auto-generated module.
-    @test sprint(show, Fruit.Apple;  context = :compact => true) == "Fruit.Apple"
+    @test sprint(show, Fruit.Apple; context = :compact => true) == "Fruit.Apple"
     @test sprint(show, Fruit.Banana; context = :compact => true) == "Fruit.Banana"
 
 


### PR DESCRIPTION
`Base`'s fallback `show(::IO, ::Enum)` drops the module qualifier when `IOContext` has `:compact => true`, resulting in just the bare instance name (e.g. `Apple`). For `EnumX` enums this is not round-trippable since the instances are inside the scoped of the auto-generated module.

Therefore, override `Base.show(::IO, ::E) where {E <: EnumX.Enum}` to always use `Module.Name`, matching the form already used by the existing 3-arg `show` and by `repr(...)` outside of compact contexts.

Fixes #7.